### PR TITLE
Fix: Add monster level to exp instead of name (fixes #4)

### DIFF
--- a/script.js
+++ b/script.js
@@ -379,7 +379,7 @@ text.innerText = "You dodge the attack from the " + monsters[fighting].name + ".
 //Create defeatMonster and lose function
 function defeatMonster() { //Update gold calculation in defeatMonster function to be 6.7 times the monsters lvl
 gold += Math.floor(monsters[fighting].level * 6.7) + 1;
-    exp += monsters[fighting].name;                                                  //Show th exp gained in exp = exp + monsters lvl user fought
+exp += monsters[fighting].level;                                                //Show th exp gained in exp = exp + monsters lvl user fought
    goldText.innerText = gold;
    expText.innerText = exp;                                       //Update the values to be displayed now on screen using innerText
    update(locations[4]);                        //Complete defeatMonster function by calling update with locations[4].<--This does notexist, yet


### PR DESCRIPTION


## What was wrong?
- Experience (`exp`) was being incremented by the monster's name (a string), causing `exp` to become a string and break experience tracking.

## What’s changed?
- Now, `exp` is incremented by the monster's level (a number), as intended:
  ```js
  exp += monsters[fighting].level;
  ```

Closes #4
