### PR TITLE
Fix: Store weapon name in inventory instead of function (fixes #1)

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,7 +186,7 @@ function myWeapon() {   // create function to take the actions that happen in "s
   goldText.innerText = gold;
   let newWeapon = weapons[currentWeaponIndex].name;//use the dot notation for new weapon
   text.innerText = "You now have a " + newWeapon + "."  //create the commentary log when you purchase a new weapon from store
-  inventory.push(myWeapon); //show the log commentary of the new equipped weapon
+  inventory.push(newWeapon); //show the log commentary of the new equipped weapon
   text.innerText += " In your inventory you have: " + inventory//after the updated innerText for the new weapon log commentary include the inventory text using a second innerText with +=
                                                                 //add the inventory operation by concatinating
     }                                                              // add an else statement if the gold you have is insufficient 


### PR DESCRIPTION


## What was wrong?
- When buying a weapon, the function `myWeapon` was being pushed to the inventory array instead of the weapon’s name, causing display and logic errors.

## What’s changed?
- Now, the weapon’s name (`newWeapon`) is pushed to the inventory:
  ```js
  inventory.push(newWeapon);
  ```



Closes #1


